### PR TITLE
Update Podspec

### DIFF
--- a/URBNSwiftAlert.podspec
+++ b/URBNSwiftAlert.podspec
@@ -11,5 +11,5 @@ s.source           = { :git => 'git@github.com:urbn/URBNSwiftAlert.git', :tag =>
 s.platform         = :ios, '10.0'
 s.requires_arc     = true
 s.source_files     = 'URBNSwiftAlert/Classes/**/*'
-s.dependency 'URBNSwiftyConvenience', '~> 0.3.3'
+s.dependency 'URBNSwiftyConvenience', '~> 0.4'
 end


### PR DESCRIPTION
This is currently causing a conflict with URBNSwiftyConveneince 0.4.1.

If we’re going to use `~>` operator, we should use it for 2 places, not 3. This will support URBNConvenience up to (but not including) `1.0`

Do we even want to put a version specifier in? We need at least URBNConvenience 0.3.3 to work. We could do `>= 0.3.3` or even remove it all together and hope the Podfile doesn't contain an older version.