### PR TITLE
alert styler init now public

### DIFF
--- a/URBNSwiftAlert/Classes/AlertStyler.swift
+++ b/URBNSwiftAlert/Classes/AlertStyler.swift
@@ -10,6 +10,8 @@ import URBNSwiftyConvenience
 
 public struct AlertStyler {
     
+    public init() {}
+    
     public var blur: Blur = Blur()
     
     public var background = Background()


### PR DESCRIPTION
The purpose of this PR is to make the AlertStyler's init public so WhiteLabel clients can init and style their own alerts.