### PR TITLE
accessibilityIdentifiers for Mobile QA team

### DIFF
--- a/URBNSwiftAlert/Classes/AlertButton.swift
+++ b/URBNSwiftAlert/Classes/AlertButton.swift
@@ -46,7 +46,7 @@ public class AlertButton: UIButton {
         layer.shadowColor = styler.button.shadowColor.cgColor
         layer.shadowOffset = styler.button.shadowOffset
         contentEdgeInsets = styler.button.contentInsets
-        accessibilityIdentifier = "URBNAlert-button"
+        accessibilityIdentifier = "alertButton"
     }
     
     public override var isHighlighted: Bool {

--- a/URBNSwiftAlert/Classes/AlertButton.swift
+++ b/URBNSwiftAlert/Classes/AlertButton.swift
@@ -46,6 +46,7 @@ public class AlertButton: UIButton {
         layer.shadowColor = styler.button.shadowColor.cgColor
         layer.shadowOffset = styler.button.shadowOffset
         contentEdgeInsets = styler.button.contentInsets
+        accessibilityIdentifier = "URBNAlert-button"
     }
     
     public override var isHighlighted: Bool {

--- a/URBNSwiftAlert/Classes/AlertController.swift
+++ b/URBNSwiftAlert/Classes/AlertController.swift
@@ -70,6 +70,7 @@ public class AlertController: NSObject {
         }
         alertWindow?.windowLevel = UIWindowLevelAlert
         alertWindow?.isHidden = false
+        alertWindow?.accessibilityIdentifier = "URBNAlert-window"
         
         NotificationCenter.default.addObserver(self, selector: #selector(resignActive) , name:  Notification.Name(rawValue: "UIWindowDidBecomeKeyNotification")  , object: nil)
     }

--- a/URBNSwiftAlert/Classes/AlertController.swift
+++ b/URBNSwiftAlert/Classes/AlertController.swift
@@ -70,7 +70,7 @@ public class AlertController: NSObject {
         }
         alertWindow?.windowLevel = UIWindowLevelAlert
         alertWindow?.isHidden = false
-        alertWindow?.accessibilityIdentifier = "URBNAlert-window"
+        alertWindow?.accessibilityIdentifier = "alertWindow"
         
         NotificationCenter.default.addObserver(self, selector: #selector(resignActive) , name:  Notification.Name(rawValue: "UIWindowDidBecomeKeyNotification")  , object: nil)
     }

--- a/URBNSwiftAlert/Classes/AlertView.swift
+++ b/URBNSwiftAlert/Classes/AlertView.swift
@@ -83,6 +83,7 @@ extension AlertView {
             titleLabel.lineBreakMode = .byWordWrapping
             titleLabel.textColor = configuration.styler.title.color
             titleLabel.text = title
+            titleLabel.accessibilityIdentifier = "URBNAlert-title"
             stackView.addArrangedSubview(titleLabel.wrapInNewView(with: configuration.styler.title.insetConstraints))
         }
         
@@ -93,6 +94,7 @@ extension AlertView {
             messageView.textColor = configuration.styler.message.color
             messageView.isEditable = false
             messageView.text = message
+            messageView.accessibilityIdentifier = "URBNAlert-message"
             
             let buttonH = configuration.customButtons?.containerViewHeight ?? configuration.styler.button.height
             let maxTextViewH = UIScreen.main.bounds.height - titleLabel.intrinsicContentSize.height - 150.0 - (configuration.styler.alert.insets.top) * 2 - buttonH
@@ -131,6 +133,7 @@ extension AlertView {
             textFieldErrorLabel.font = configuration.styler.textField.errorMessageFont
             stackView.addArrangedSubview(textFieldErrorLabel)
             textFieldErrorLabel.isHidden = true
+            textFieldErrorLabel.accessibilityIdentifier = "URBNAlert-textFieldError"
         }
     }
     

--- a/URBNSwiftAlert/Classes/AlertView.swift
+++ b/URBNSwiftAlert/Classes/AlertView.swift
@@ -83,7 +83,7 @@ extension AlertView {
             titleLabel.lineBreakMode = .byWordWrapping
             titleLabel.textColor = configuration.styler.title.color
             titleLabel.text = title
-            titleLabel.accessibilityIdentifier = "URBNAlert-title"
+            titleLabel.accessibilityIdentifier = "alertTitle"
             stackView.addArrangedSubview(titleLabel.wrapInNewView(with: configuration.styler.title.insetConstraints))
         }
         
@@ -94,7 +94,7 @@ extension AlertView {
             messageView.textColor = configuration.styler.message.color
             messageView.isEditable = false
             messageView.text = message
-            messageView.accessibilityIdentifier = "URBNAlert-message"
+            messageView.accessibilityIdentifier = "alertMessage"
             
             let buttonH = configuration.customButtons?.containerViewHeight ?? configuration.styler.button.height
             let maxTextViewH = UIScreen.main.bounds.height - titleLabel.intrinsicContentSize.height - 150.0 - (configuration.styler.alert.insets.top) * 2 - buttonH
@@ -133,7 +133,7 @@ extension AlertView {
             textFieldErrorLabel.font = configuration.styler.textField.errorMessageFont
             stackView.addArrangedSubview(textFieldErrorLabel)
             textFieldErrorLabel.isHidden = true
-            textFieldErrorLabel.accessibilityIdentifier = "URBNAlert-textFieldError"
+            textFieldErrorLabel.accessibilityIdentifier = "alertTextFieldError"
         }
     }
     

--- a/URBNSwiftAlert/Classes/AlertViewController.swift
+++ b/URBNSwiftAlert/Classes/AlertViewController.swift
@@ -284,6 +284,7 @@ extension AlertViewController {
     
     public func addTextfield(configurationHandler: ((UITextField) -> Void)) {
         let tf = UITextField()
+        tf.accessibilityIdentifier = "URBNAlert-textField"
         alertConfiguration.textFields.append(tf)
         configurationHandler(tf)
     }

--- a/URBNSwiftAlert/Classes/AlertViewController.swift
+++ b/URBNSwiftAlert/Classes/AlertViewController.swift
@@ -284,7 +284,7 @@ extension AlertViewController {
     
     public func addTextfield(configurationHandler: ((UITextField) -> Void)) {
         let tf = UITextField()
-        tf.accessibilityIdentifier = "URBNAlert-textField"
+        tf.accessibilityIdentifier = "alertTextField"
         alertConfiguration.textFields.append(tf)
         configurationHandler(tf)
     }


### PR DESCRIPTION
added accessibilityIdentifiers for the alert window, title, message, buttons, text fields and errors